### PR TITLE
Drop ErlangCentral

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot -w dribbble.com,beta.erlangcentral.org README.md
+  - awesome_bot -w dribbble.com README.md

--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ A curated list of awesome niche job boards.
 
 * [Elixir Jobs](https://elixir.career/)
 
-### Erlang
-
-* [ErlangCentral](https://beta.erlangcentral.org/jobs)
-
 ### Front-End
 
 * [Front-End Developer Jobs](http://frontenddeveloperjob.com/)


### PR DESCRIPTION
The beta.erlangcentral.org URL domain no longer resolves, and
https://erlangcentral.org/jobs doesn't return any active jobs.