### PR TITLE
Add WeJob.ch

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A curated list of awesome niche job boards.
 
 * [Landing.jobs](https://landing.jobs/?utm_source=github&utm_medium=referral&utm_content=whfio&utm_campaign=post)
 * [SwissDev Jobs](https://swissdevjobs.ch/) - Jobs for Software Developers from the EU that want to work in Switzerland
+* [WeJob.ch](https://WeJob.ch/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - Developers and IT Jobs in Switzerland 🇨🇭
 
 ### United Kingdom
 


### PR DESCRIPTION
Would be great to add: WeJob.ch - The #1 Job Board dedicated to Developers and IT Specialists in Switzerland :-)