### PR TITLE
Add Career Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ A curated list of awesome niche job boards.
 
 ### Aggregator
 
+* [Career Vault](https://careervault.io/) - Thousands of remote jobs scraped from 900+ companies every few hours
 * [remote | OK](https://remoteok.io/)
 * [whoishiring.io](https://whoishiring.io/)
 * [remote4me.com](https://remote4me.com/)


### PR DESCRIPTION
Career Vault finds over 10x more remote jobs than other popular job boards, such as RemoteOK and WeWorkRemotely, and links applicants directly to the original job posting. It's free for job seekers and companies, doesn't require signing up, and doesn't have any obsolete postings (those are automatically deleted).