### PR TITLE
Add 'JavaScript Works' to JS jobs board section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A curated list of awesome niche job boards.
 * [Vue.js Jobs](https://vuejobs.com/)
 * [We Work Meteor](https://www.weworkmeteor.com/)
 * [Svelte Jobs](https://sveltejobs.dev/)
+* [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source.
 
 ### Perl
 
@@ -164,7 +165,7 @@ A curated list of awesome niche job boards.
 
 ### Canada
 
-* [Work in Tech](https://www1.communitech.ca/jobs) - Explore opportunities in Waterloo Region and beyond 
+* [Work in Tech](https://www1.communitech.ca/jobs) - Explore opportunities in Waterloo Region and beyond
 
 ### Europe
 


### PR DESCRIPTION
In this PR we introduce '[JavaScript Works](https://javascript.works-hub.com/)'  which is a jobs board and community website for JavaScript work opportunities.