### PR TITLE
Removing careervault.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ A curated list of awesome niche job boards.
 ### Aggregator
 
 * [4 day week](https://4dayweek.io/) - Software jobs with a better work-life balance
-* [Career Vault](https://careervault.io/) - Thousands of remote jobs scraped from 900+ companies every few hours
 * [remote | OK](https://remoteok.io/)
 * [whoishiring.io](https://whoishiring.io/)
 * [remote4me.com](https://remote4me.com/)


### PR DESCRIPTION
Throwing a 502, will add back it when it's back up.