### PR TITLE
Add Dynamite Jobs board

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ A curated list of awesome niche job boards.
 * [Werkington](https://www.werkington.com/)
 * [EqualOpportunity.Work](https://equalopportunity.work/)
 * [Just Remote](https://justremote.co/remote-jobs)
+* [Dynamite Jobs](https://www.dynamitejobs.com/) - Jobs from remote-first companies
 
 ### Aggregator
 


### PR DESCRIPTION
Add [Dynamite Jobs](https://www.dynamitejobs.com/), a job board for remote-first companies.