### PR TITLE
Revert "Removing all works-hub.com sites (#126)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A curated list of awesome niche job boards.
 * [Crypto Jobs List](https://cryptojobslist.com/) - Crypto Jobs List is your #1 board to find and post crypto, bitcoin and blockchain jobs.
 * [Crypto Job](https://crypto-job.com/) - Crypto Job is the place where talent meets opportunity. Our goal is to connect passionate blockchain and cryptocurrency developers with companies that value their talent and expertise.
 * [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
+* [Blockchain Works](https://blockchain.works-hub.com/jobs) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
 * [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!
 
 ## Cloud
@@ -98,6 +99,7 @@ A curated list of awesome niche job boards.
 
 * [FunctionalJobs.dev](https://functionaljobs.dev/) - Highly active job board for functional programming enthusiasts
 * [Functional Jobs](https://www.functionaljobs.com/) - Job board for functional programmers
+* [Functional Works](https://functional.works-hub.com/jobs) - Discover local and remote functional programming opportunities
 
 ### Go
 
@@ -105,6 +107,7 @@ A curated list of awesome niche job boards.
 * [we love golang](https://www.welovegolang.com/)
 * [Golang Forum Jobs](https://forum.golangbridge.org/c/jobs/8)
 * [Golang Developer Jobs](https://golangjob.xyz)
+* [Golang Works](https://golang.works-hub.com/jobs) - Local and remote Golang opportunities, articles and open-source.
 
 ### JavaScript
 
@@ -114,6 +117,7 @@ A curated list of awesome niche job boards.
 * [We Work Meteor](https://www.weworkmeteor.com/)
 * [React Jobs](https://reactjsjob.com)
 * [Svelte Jobs](https://sveltejobs.dev/)
+* [Javascript Works](https://javascript.works-hub.com/jobs) - Local and remote JavaScript opportunities, articles and open-source.
 
 ### Kotlin
 * [Kotlin Jobs](https://kotlinjobs.dev)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A curated list of awesome niche job boards.
 * [Crypto Jobs List](https://cryptojobslist.com/) - Crypto Jobs List is your #1 board to find and post crypto, bitcoin and blockchain jobs.
 * [Crypto Job](https://crypto-job.com/) - Crypto Job is the place where talent meets opportunity. Our goal is to connect passionate blockchain and cryptocurrency developers with companies that value their talent and expertise.
 * [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/) - The leading job board for blockchain and cryptocurrency jobs
-* [Blockchain Works](https://blockchain.works-hub.com/jobs) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
+* [Blockchain Works](https://blockchain.works-hub.com/) - Discover **the best** Blockchain opportunities and articles with **Blockchain Works**
 * [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!
 
 ## Cloud
@@ -99,7 +99,7 @@ A curated list of awesome niche job boards.
 
 * [FunctionalJobs.dev](https://functionaljobs.dev/) - Highly active job board for functional programming enthusiasts
 * [Functional Jobs](https://www.functionaljobs.com/) - Job board for functional programmers
-* [Functional Works](https://functional.works-hub.com/jobs) - Discover local and remote functional programming opportunities
+* [Functional Works](https://functional.works-hub.com/) - Discover local and remote functional programming opportunities
 
 ### Go
 
@@ -107,7 +107,7 @@ A curated list of awesome niche job boards.
 * [we love golang](https://www.welovegolang.com/)
 * [Golang Forum Jobs](https://forum.golangbridge.org/c/jobs/8)
 * [Golang Developer Jobs](https://golangjob.xyz)
-* [Golang Works](https://golang.works-hub.com/jobs) - Local and remote Golang opportunities, articles and open-source.
+* [Golang Works](https://golang.works-hub.com/) - Local and remote Golang opportunities, articles and open-source.
 
 ### JavaScript
 
@@ -117,7 +117,7 @@ A curated list of awesome niche job boards.
 * [We Work Meteor](https://www.weworkmeteor.com/)
 * [React Jobs](https://reactjsjob.com)
 * [Svelte Jobs](https://sveltejobs.dev/)
-* [Javascript Works](https://javascript.works-hub.com/jobs) - Local and remote JavaScript opportunities, articles and open-source.
+* [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source.
 
 ### Kotlin
 * [Kotlin Jobs](https://kotlinjobs.dev)
@@ -170,6 +170,7 @@ A curated list of awesome niche job boards.
 ### Aggregator
 
 * [4 day week](https://4dayweek.io/) - Software jobs with a better work-life balance
+* [Career Vault](https://careervault.io/) - Thousands of remote jobs scraped from 900+ companies every few hours
 * [remote | OK](https://remoteok.com/)
 * [whoishiring.io](https://whoishiring.io/)
 * [remote4me.com](https://remote4me.com/)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ A curated list of awesome niche job boards.
 ### Aggregator
 
 * [4 day week](https://4dayweek.io/) - Software jobs with a better work-life balance
-* [Career Vault](https://careervault.io/) - Thousands of remote jobs scraped from 900+ companies every few hours
 * [remote | OK](https://remoteok.com/)
 * [whoishiring.io](https://whoishiring.io/)
 * [remote4me.com](https://remote4me.com/)


### PR DESCRIPTION
This reverts commits a05de067e13437b48555c1758fe6cee92a134541 and 84197d438f19b9d090056d02658595ad1ccc100e
Previous PRs: https://github.com/tramcar/awesome-job-boards/pull/126 and https://github.com/tramcar/awesome-job-boards/pull/123

WorksHub had a production issue over the holiday period and temporarily redirected to `/jobs` using 307. The issue is now resolved. Sincere apologies for any inconvenience this would have caused.