### PR TITLE
Add Jobbsy job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of awesome niche job boards.
 * [jobs.wordpress.net](https://jobs.wordpress.net/)
 * [LaraJobs](https://larajobs.com/)
 * [WPhired](https://www.wphired.com/) - WordPress Jobs
+* [Jobbsy](https://jobbsy.dev) - Symfony Jobs
 
 ### Python
 


### PR DESCRIPTION
[Jobbsy](https://jobbsy.dev) is the first and [open source](https://github.com/jobbsy-dev/jobbsy) job board dedicated to Symfony framework.