### PR TITLE
Add Woody3 to Blockchain job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A curated list of awesome niche job boards.
 * [Web3 Jobs](https://web3.career) - Looking for a web3 job? Web3 Jobs has 8,387+ web3 remote and offline jobs as Web3 Developer, Smart Contract Developer, Solidity Developer and much more. Switch your career to Web3 and join the future!
 * [Remote Web3 Jobs](https://remote3.co) - A remote web3 job board onboarding people to web3 sharing web3 content, guides & tutorials for free.
 * [My Web3 Jobs](https://myweb3jobs.com) - Find or Post web3 Jobs Today! New web3 Blockchain, Developer, and Designer Jobs handpicked every week.
+* [Woody3](https://www.woody3.xyz/) - Find your dream non-tech job in Web3
 
 ## Cloud
 


### PR DESCRIPTION
Adding Woody3, job board exclusively for non-tech roles in Web3 