### PR TITLE
Add RubyOnRemote as Ruby Job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ A curated list of awesome niche job boards.
 ### Ruby
 
 * [RubyNow](https://jobs.rubynow.com/)
+* [RubyOnRemote](https://rubyonremote.com) - Remote jobs for Ruby developers
 
 ### Rust
 


### PR DESCRIPTION
Hi,

Adding a ruby only remote job board for your list.

