### PR TITLE
Add Python Devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ A curated list of awesome niche job boards.
 * [Python Job Board](https://www.python.org/jobs/)
 * [Django Jobs](https://djangojobs.net/jobs/)
 * [Python Developer Jobs](https://pythonjob.xyz)
-[Python Devs](https://www.pythondevs.net)
+* [Python Devs](https://www.pythondevs.net)
 
 ### Ruby
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of awesome niche job boards.
 * [Python Job Board](https://www.python.org/jobs/)
 * [Django Jobs](https://djangojobs.net/jobs/)
 * [Python Developer Jobs](https://pythonjob.xyz)
+[Python Devs](https://www.pythondevs.net)
 
 ### Ruby
 


### PR DESCRIPTION
Added a link to PythonDevs (reverse jobs board for Python developers) - https://www.pythondevs.net