### PR TITLE
Adding aijobs.dev website into the Artificial Intelligence list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of awesome niche job boards.
 
 ## Artificial Intelligence (AI)
 
+* [AI Jobs Dev](https://aijobs.dev) - Discover companies looking to hire AI, ML, Data Science & Big Data engineers and connect with them.
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [ai-jobs.net](https://ai-jobs.net/) - Jobs in AI and Big Data
 * [thrive](https://thriveml.com) - Jobs at Top AI Companies and Startups


### PR DESCRIPTION
I used [AI Jobs Dev](https://aijobs.dev) in my job search and it was useful.