### PR TITLE
Include androiddev.careers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of awesome niche job boards.
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
 * [Dev Employ](https://devemploy.com/) - Hand-picked developer jobs
+* [androiddev.careers](http://androiddev.careers/) – Job board for Android developers
 
 ### Clojure
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A curated list of awesome niche job boards.
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
 * [Dev Employ](https://devemploy.com/) - Hand-picked developer jobs
-* [androiddev.careers](http://androiddev.careers/) – Job board for Android developers
+* [androiddev.careers](https://androiddev.careers/) – Job board for Android developers
 
 ### Clojure
 


### PR DESCRIPTION
This PR includes androiddev.careers to the list of Aggregators, which is a job board for Android Developers