### PR TITLE
Feat: mecruit job board added under Aggregator category

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A curated list of awesome niche job boards.
 
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
+* [Mecruit Job Board](https://www.mecruit.com/)
 
 ### Clojure
 


### PR DESCRIPTION
Hi,

I have added my Job Board in your repo under the ##Aggregator category.

The job boards is - https://www.mecruit.com/

We claim to offer extensive filter options to job applicants(eg: remote, visa sponsored, salary mentioned etc)
which helps job applicants to find job openings fast with only the filters that matter to them.

We also have a newsletter for the preferred filters of the job applicants.

Please help us by sharing this job board in your repository.

Best Regards