### PR TITLE
Add 4DayJob to Remote section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ A curated list of awesome niche job boards.
 * [Dynamite Jobs](https://dynamitejobs.com/) - Jobs from remote-first companies
 * [Teletravail.guru](https://teletravail.guru/) - Remote jobs for people located in France
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
-* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
+* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people
+* [4DayJob](https://4dayjob.com/) - 4-day work week and remote job board with 1,500+ flexible opportunities
 
 ## Quantum Computing
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ A curated list of awesome niche job boards.
 * [Just Remote](https://justremote.co/remote-jobs)
 * [Dynamite Jobs](https://dynamitejobs.com/) - Jobs from remote-first companies
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
-* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people
+* [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
 * [4DayJob](https://www.4dayjob.com/) - 4-day work week and remote job board with 1,000+ listings across 10 categories
 
 ## Quantum Computing

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ A curated list of awesome niche job boards.
 * [Dynamite Jobs](https://dynamitejobs.com/) - Jobs from remote-first companies
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
 * [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people
-* [4DayJob](https://4dayjob.com/) - 4-day work week and remote job board with 1,500+ flexible opportunities
+* [4DayJob](https://www.4dayjob.com/) - 4-day work week and remote job board with 1,000+ listings across 10 categories
 
 ## Quantum Computing
 


### PR DESCRIPTION
Add [4DayJob](https://4dayjob.com/) to the Remote section.

4DayJob is a job board focused on 4-day work week and remote opportunities, featuring 1,500+ listings from companies offering flexible schedules. It complements the existing 4-day week listings in the Aggregator section by focusing specifically on verified 4-day and remote positions.

- Link is working and has current job listings
- Added to the bottom of the Remote category per guidelines