### PR TITLE
Add Human Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
+* [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. Zero platform fees
 
 ## Big Data
 


### PR DESCRIPTION
Adds [Human Pages](https://humanpages.ai) — the open directory AI agents use to hire humans for real-world tasks. Zero platform fees.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages