### PR TITLE
Add JobsByCulture to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
+* [JobsByCulture](https://jobsbyculture.com/) - Culture-first AI & tech job board with Glassdoor ratings, culture values, and employee reviews for 45+ companies.
 
 ## Big Data
 


### PR DESCRIPTION
Adds [JobsByCulture](https://jobsbyculture.com/) to the Artificial Intelligence (AI) section.

JobsByCulture is a culture-first job board for AI & tech companies — profiles 45+ companies with Glassdoor ratings, work-life balance scores, culture values, and real employee reviews. 7,100+ live jobs from Anthropic, OpenAI, Databricks, Stripe, Figma, and more.