### PR TITLE
Add Agentic Engineering Jobs to Artificial Intelligence (AI) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
+* [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 
 ## Big Data
 


### PR DESCRIPTION
Adding https://agentic-engineering-jobs.com — a job board for engineers building agentic systems (RAG pipelines, AI agents, LLM-powered products, agent orchestration).

- 500+ active listings
- Free to post for companies, free to browse for job seekers
- Remote and global roles
- Appended to the bottom of the Artificial Intelligence (AI) category per CONTRIBUTING.md

Happy to adjust description or placement if needed.