### PR TITLE
Add AI Dev Jobs to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A curated list of awesome niche job boards.
 
 ## Artificial Intelligence (AI)
 
+* [AI Dev Jobs](https://aidevboard.com/) - AI/ML job board with public REST API and MCP server. 5,400+ jobs aggregated from 55+ ATS sources, updated daily.
 * [AI Jobs](https://www.moaijobs.com/) - AI Jobs in ML, Data Science, Engineering, and Research
 * [AI Jobs](https://aijobs.app) – Jobs in Artificial Intelligence (AI)
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com/) to the **Artificial Intelligence (AI)** section in alphabetical order.

AI Dev Jobs is an AI/ML job board that aggregates 5,400+ jobs from 55+ ATS sources, updated daily. It provides a public REST API and MCP server for programmatic job search.

Entry follows the existing `* [Name](url) - Description` format.