### PR TITLE
Add AI Dev Jobs to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
+* [AI Dev Jobs](https://aidevboard.com) - AI developer jobs with salary data, REST API, and MCP server for 370+ companies
 
 ## Big Data
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Artificial Intelligence (AI) section.

AI Dev Jobs indexes 7,200+ AI/ML developer positions from 370+ companies (Anthropic, OpenAI, Scale AI, etc.) with published salary data. It also offers a REST API and MCP server for programmatic access.