### PR TITLE
Add AI Dev Jobs to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [AI/ML Jobs](https://www.aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!
 * [AI Jobster](https://aijobster.work/) - Jobs from leading AI companies, across all group.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
+* [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 
 ## Big Data
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com/) to the Artificial Intelligence (AI) section.

AI Dev Jobs is an AI/ML job board with 7,400+ jobs from 417+ companies (Anthropic, OpenAI, Google DeepMind, etc.). It differentiates from existing entries by offering a REST API and MCP server for programmatic/agent-powered job search — no other listed board has this. The board has been live for 6+ months with active listings updated daily.