### PR TITLE
Add usdevjobs.com to Job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of awesome niche job boards.
 * [BerlinStartupJobs](https://berlinstartupjobs.com/) - The hottest jobs at Berlin's finest startups and scaleups since 2011
 * [Startup Jobs](https://startup.jobs/)
 * [coolstartupjobs](https://www.coolstartupjobs.com) - Find jobs at growing startups
+* [USDevJobs](https://usdevjobs.com) - Real time job aggregator for software, AI/ML, and data engineer jobs from US startups
 * [Work in biotech](https://workinbiotech.com/) - Find a biotech startup job
 
 ## Tech


### PR DESCRIPTION
Please Adds [US Dev Jobs](https://usdevjobs.com/) to the Job boards section.

- 1,000+ Software, AI/ML, Data engineering roles from US startups daily.
- Aggregated only US jobs from Linkedin, Indeed, recruiting/staffing agencies.
- The job list is updated hourly.
- Filter by remote , title, url, company, date.

Thank you for maintaining this list!