### PR TITLE
Add Hanzilla Jobs to Canada job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ A curated list of awesome niche job boards.
 ### Canada
 
 * [Work in Tech](https://www1.communitech.ca/jobs) - Explore opportunities in Waterloo Region and beyond
+* [Hanzilla Jobs](https://jobs.hanzilla.co/) - Daily-updated Canadian student and recent-grad jobs across internships, co-ops, new grad, junior, and entry-level roles
 
 ### Europe
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Canada section.
- It is a daily-updated Canadian student/recent-grad board covering internships, co-ops, new grad, junior, and entry-level roles across fields.

## Checklist
- [x] Added one suggestion to the relevant category
- [x] Confirmed it has current job listings