### PR TITLE
Add Gridnaut Recruiting to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A curated list of awesome niche job boards.
 * [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 * [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 
+* [Gridnaut Recruiting](https://gridnaut.site/jobs/) - Curated AI training, evaluation, and domain-expert contractor roles (Mercor referrals). 100% remote, hourly contracts.
+
 ## Big Data
 
 * [DataJobs.com](https://datajobs.com/)


### PR DESCRIPTION
Adding [Gridnaut Recruiting](https://gridnaut.site/jobs/) — a job board listing AI training, evaluation, and domain-expert contract roles curated from Mercor.

- 100% remote, hourly contractors ($23–$180/hr)
- ~73 active listings, refreshed weekly
- Roles: AI evaluators, domain experts (medicine, law, engineering, physics PhD, etc.), bilingual evaluators
- JobPosting structured data validates against Google for Jobs

Inserted at the top of the Artificial Intelligence (AI) section.