### PR TITLE
Add Hanzilla Jobs to Canada job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ A curated list of awesome niche job boards.
 ### Canada
 
 * [Work in Tech](https://www1.communitech.ca/jobs) - Explore opportunities in Waterloo Region and beyond
+* [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Daily-updated Canadian student internships, co-ops, new-grad, junior, and entry-level roles across tech and adjacent fields
 
 ### Europe
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Canada subsection of the Tech job boards list.
- Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad job board covering internships, co-ops, new-grad, junior, and entry-level roles.

## Link
https://jobs.hanzilla.co/internships/

## Checks
- Confirmed the site is live and current: homepage, robots.txt, sitemap index, pages sitemap, and jobs sitemap return 200.
- Current jobs sitemap has 1,324 job URLs with newest `lastmod` 2026-05-18.
- Sampled job pages include valid JobPosting structured data.
- Ran `git diff --check`.
