### PR TITLE
Add warpjobs to Artificial Intelligence (AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
 * [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 * [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
+* [warpjobs](https://warpjobs.com) - GPU/CUDA, ML-systems, inference & performance-engineering roles aggregated daily from AI-lab & infra companies' ATS feeds; open-source scraper, RSS + JSON feeds.
 
 ## Big Data
 


### PR DESCRIPTION
Adds **warpjobs** (https://warpjobs.com) to the Artificial Intelligence (AI) section.

It's a free, daily-refreshed board narrowly focused on **GPU/CUDA, ML-systems, inference and performance-engineering** roles, aggregated from AI-lab and infra companies' public ATS feeds (Greenhouse / Lever / Ashby) - a more specialized peer to the AI boards already listed. Open-source scraper, RSS (`/feed.xml`) + JSON (`/jobs.json`) feeds, no login or paywall. ~115 live roles from 23 companies. Appended to the section to match the format and recent additions.
