### PR TITLE
Add caio.pro to Artificial Intelligence (AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
 * [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 * [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
+* * [caio.pro](https://caio.pro) - C-level AI leadership jobs (Chief AI Officer, VP of AI, Head of AI/ML, Chief Data Officer), every listing AI-verified and enriched.
 
 ## Big Data
 


### PR DESCRIPTION
caio.pro is an established job board focused exclusively on C-level AI leadership roles (Chief AI Officer, VP of AI, Head of AI/ML, Chief Data Officer). It has current listings, every posting is AI-verified and enriched, and it's free to browse. Added to the bottom of the Artificial Intelligence (AI) category per CONTRIBUTING.md.