### PR TITLE
Add Hanzilla Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A curated list of awesome niche job boards.
 
 ### Canada
 
+* [Hanzilla Jobs](https://jobs.hanzilla.co/) - Daily-updated Canadian student internships, co-ops, new-grad, junior, and entry-level roles
 * [Work in Tech](https://www1.communitech.ca/jobs) - Explore opportunities in Waterloo Region and beyond
 
 ### Europe


### PR DESCRIPTION
## Summary

Adds Hanzilla Jobs to the Canada section.

Resource: https://jobs.hanzilla.co/

## Why include it

- Canada-specific job board for students and recent graduates.
- Daily-updated listings across internships, co-ops, new-grad, junior, and entry-level roles.
- Covers tech plus adjacent early-career fields such as engineering, business, finance, and sciences.
