### PR TITLE
Add Meridian to Remote section

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of awesome niche job boards.
 ## Remote
 
 * [100% Work From Anywhere jobs](https://www.realworkfromanywhere.com/) - Fully remote jobs to live and work from anywhere
+* [Meridian](https://meridianremote.com/) - Remote tech jobs matched to your timezone for US, LATAM, and EU; aggregated and deduplicated from top boards and ATS feeds
 * [We Work Remotely](https://weworkremotely.com/)
 * [DailyRemote](https://dailyremote.com/)
 * [Werkington](https://www.werkington.com/)


### PR DESCRIPTION
Adds [Meridian](https://meridianremote.com) — a remote tech job board that matches roles to your timezone for US, LATAM, and EU professionals, aggregating and deduplicating listings from top boards and ATS feeds while linking to the original posting.