### PR TITLE
Add JobsGlitch — ATS-sourced job listings aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A curated list of awesome niche job boards.
 * [findwork.dev](https://findwork.dev/)
 * [Levels.fyi](https://www.levels.fyi/jobs)
 * [GrepJob.com](https://grepjob.com/) - Software Engineering jobs scraped from established company career pages
+* [JobsGlitch](https://jobsglitch.com) - Job listings indexed directly from company ATS platforms (Workday, Greenhouse, Lever, iCIMS) before they reach LinkedIn or aggregators
 
 ### Clojure
 


### PR DESCRIPTION
## What is JobsGlitch?

[JobsGlitch](https://jobsglitch.com) indexes job listings directly from company ATS platforms — Workday, Greenhouse, Lever, and iCIMS — before they reach LinkedIn or aggregators.

Similar to GrepJob (already in this list) but focused on ATS ingestion rather than career page scraping.

## Why it fits this list

- Aggregates jobs from primary sources (ATS), not from other job boards
- Free to use
- Covers all industries and locations globally