### PR TITLE
Add DACH Early-Career Jobs to Europe section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of awesome niche job boards.
 * [Next Level Jobs EU](https://nextleveljobs.eu/?utm_source=github&utm_medium=referral&utm_campaign=tramcar-awesome-job-boards) - €100k+ Software Engineering Jobs 🇪🇺
 * [Work In Tech](https://www1.communitech.ca/jobs) - Find your next role at Canada's fastest-growing tech companies
 * [Defence jobs in Europe](https://www.defencejobs.org) - The main job board for European defence 🇪🇺
+* [DACH Early-Career Jobs](https://github.com/heynish/werkstudent-praktikum-jobs) - Werkstudent, Praktikum & new-grad roles across Germany, Austria & Switzerland 🇩🇪🇦🇹🇨🇭
 
 ### Latin America
 


### PR DESCRIPTION
Adds an established, auto-updating job board for early-career tech roles across Germany, Austria & Switzerland to the Tech > Europe section.

- ~1,000 current live listings, refreshed daily
- Sourced from public company ATS APIs (Greenhouse/Lever/Ashby/Personio) + the German Federal Employment Agency
- Every listing links to the original posting; free, no signup

Appended to the bottom of the Europe category per CONTRIBUTING. Thanks!