### PR TITLE
Add ChainJobs to Blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of awesome niche job boards.
 * [Woody3](https://www.woodyjobs.com) - Find your dream non-tech job in Web3
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
 * [GMI Jobs](https://gmijobs.com) - Crypto-native job board for Web3 professionals — curated roles from 200+ blockchain companies with AI-powered job enrichment.
+* [ChainJobs](https://chainjobs.io/) - Crypto, web3 and blockchain jobs aggregated daily from companies' official careers pages, with every listing linking to the employer's own application page
 
 ## Design
 


### PR DESCRIPTION
Adds [ChainJobs](https://chainjobs.io/) to the Blockchain section.

ChainJobs aggregates crypto, web3 and blockchain roles directly from companies' official careers pages (Greenhouse, Lever, Ashby) and re-verifies them daily — roles removed at the source are removed here the same day. Currently ~2,470 live roles across 122 companies, so it meets the 'established board with current listings' guideline.

Every listing links to the employer's own application page rather than an internal apply flow, and non-technical roles (marketing, BD, community, operations) are surfaced alongside engineering.

Per CONTRIBUTING.md: searched for duplicates (none), single suggestion in this PR, title capitalized, `[List Name](link) - description` format, appended to the bottom of the Blockchain category.