### PR TITLE
Add OnlyFrontendJobs to Programming > JavaScript section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ A curated list of awesome niche job boards.
 * [Svelte Jobs](https://sveltejobs.com/)
 * [Javascript Works](https://javascript.works-hub.com/) - Local and remote JavaScript opportunities, articles and open-source
 * [JSJobbs](https://jsjobbs.com/)
+* [OnlyFrontendJobs](https://onlyfrontendjobs.com) - Hand-picked remote frontend jobs (React, Vue, Next.js, Svelte) with transparent salary details.
 
 ### Mobile
 


### PR DESCRIPTION
### Description
Adds [OnlyFrontendJobs](https://onlyfrontendjobs.com) to **Programming > JavaScript**.

**OnlyFrontendJobs** is a curated niche job board for frontend engineers working with React, Vue, Next.js, Angular, Svelte, and TypeScript.

- URL: https://onlyfrontendjobs.com
- Category: Programming > JavaScript
- Key Features: Curated remote frontend engineering roles, transparent compensation data.