### PR TITLE
Add Landed to Artificial Intelligence (AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome niche job boards.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
 * [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 * [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
+* [Landed](https://landed.jobs) - AI-native roles with fit-scored daily matches, structured remote-eligibility filters, and an MCP server for agents.
 
 ## Big Data
 


### PR DESCRIPTION
Adds Landed to the bottom of the Artificial Intelligence (AI) category.

[Landed](https://landed.jobs) is a live board of AI-native roles: AI engineer, LLM engineer, applied scientist, forward deployed engineer, GTM engineer, and similar. Listings are refreshed daily and each match carries a fit score and a short reason.

Two things that set it apart from the other AI entries here: remote eligibility is stored as canonical country and region codes separately from the physical office location, so filtering returns roles you can actually be hired into; and the board is queryable over MCP at `https://mcp.landed.jobs/mcp`, published on the Official MCP Registry as `io.github.landedjobs/landed`.

Free to browse, no login required. Link verified working, added to the bottom of the category, single suggestion in this PR, and checked for duplicates first.
