### PR TITLE
Add Web3 Jobs Radar to Blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of awesome niche job boards.
 * [Jobs In Blockchain](https://jobsinblockchain.com) - Discover latest Blockchain, Web3, Smart Contracts, Defi, NFT, Cryptocurrency related jobs
 * [GMI Jobs](https://gmijobs.com) - Crypto-native job board for Web3 professionals — curated roles from 200+ blockchain companies with AI-powered job enrichment.
 * [ChainJobs](https://chainjobs.io/) - Crypto, web3 and blockchain jobs aggregated daily from companies' official careers pages, with every listing linking to the employer's own application page
+* [Web3 Jobs Radar](https://web3jobsradar.com) - Every public web3 and crypto job aggregated daily from companies' official hiring systems (Greenhouse, Lever, Ashby), deduped and classified by role, chain, remote and salary, with a free API and MCP server
 
 ## Design
 


### PR DESCRIPTION
Adds **Web3 Jobs Radar** to the **Blockchain** section.

It aggregates every publicly posted web3/crypto job straight from companies' official hiring systems (Greenhouse, Lever, Ashby, and others) — deduplicated and classified by role, chain, remote policy and salary, with a free REST API and a hosted MCP server. Matches the existing entry format; added to the end of the Blockchain list.

Site: https://web3jobsradar.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)