### PR TITLE
Add AgenticCareers.co (AI section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A curated list of awesome niche job boards.
 * [ExploreJobs.ai](https://explorejobs.ai) - Find engineering, product, and research roles at the top AI startups.
 * [AI Dev Jobs](https://aidevboard.com) - 7,400+ AI/ML jobs from 417 companies with a free REST API and MCP server for AI agents
 * [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
+* [AgenticCareers.co](https://agenticcareers.co) - Agentic AI jobs for humans and AI agents: 1,700+ live roles from 500+ companies, updated daily, with a free JSON API and an open CC BY hiring dataset.
 * [caio.pro](https://caio.pro) - C-level AI leadership jobs (Chief AI Officer, VP of AI, Head of AI/ML, Chief Data Officer), every listing AI-verified and enriched.
 
 ## Big Data


### PR DESCRIPTION
Adds [AgenticCareers.co](https://agenticcareers.co) to the Artificial Intelligence (AI) section: a job board for the agentic economy listing 1,700+ live roles from 500+ companies, updated daily. It serves both human job seekers and AI agents (free JSON API at /api/jobs, llms.txt, and an open CC BY 4.0 hiring dataset at /state-of-agentic-hiring). Free to browse.