### PR TITLE
Add Nomado24 to Remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A curated list of awesome niche job boards.
 * [Devremote](https://devremote.io/) - Remote developer jobs at remote first companies
 * [RemoteFR](https://remotefr.com/) - Full Remote jobs for French people 
 * [4DayJob](https://www.4dayjob.com/) - 4-day work week and remote job board with 1,000+ listings across 10 categories
+* [Nomado24](https://www.nomado24.de/) - Remote and hybrid jobs in Germany and the EU (de/en/fr), with a free keyless jobs API
 
 ## Quantum Computing
 


### PR DESCRIPTION
Adds Nomado24 to the Remote section.

Nomado24 is an established job board for remote and hybrid jobs in Germany and the EU, trilingual (de/en/fr), with current listings (nearly 10,000 curated remote and hybrid jobs, 2,000+ strictly remote). It also offers a free, keyless public jobs API: https://www.nomado24.de/en/developers

Per the contribution guidelines: single suggestion, added to the bottom of the relevant category, capitalized title, `[List Name](link)` format.