### PR TITLE
Add Open Jobs Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A curated list of awesome niche job boards.
 * [EmbeddedJobs](https://embedded.jobs) - A niche job board exclusively for Embedded Systems engineers and developers.
 * [foo🦍](https://foorilla.com) - The go-to, no-nonsense, fast and lean career platform for all things coding, data and tech
 * [LeadJobs.dev](https://leadjobs.dev) - Software Engineering Leadership Jobs Board (only EM/Staff+ positions, VP, Director, CTO)
+* [Open Jobs Search](https://conorscode.github.io/open-jobs-search/) - Free search over 37,000+ live postings from 378 companies across nine ATS platforms (Greenhouse, Lever, Ashby, Workday, and more). No signup, no ads, no tracking.
 
 ### Canada
 


### PR DESCRIPTION
Adds Open Jobs Search (https://conorscode.github.io/open-jobs-search/), a free web app searching 37,000+ live job postings from 378 companies across nine ATS platforms (Greenhouse, Lever, Ashby, Workday, SmartRecruiters, Workable, Recruitee, Personio, BambooHR). No signup, no ads, no tracking. Added to the Tech section per the contribution guidelines.